### PR TITLE
Add ID to the cookie for easy access

### DIFF
--- a/lib/glogin/cookie.rb
+++ b/lib/glogin/cookie.rb
@@ -55,14 +55,14 @@ module GLogin
       # to catch in your applicaiton and ignore the login attempt.
       def to_user
         plain = Codec.new(@secret).decrypt(@text)
-        login, avatar, bearer, ctx = plain.split(GLogin::SPLIT, 4)
+        id, login, avatar, bearer, ctx = plain.split(GLogin::SPLIT, 5)
         if !@secret.empty? && ctx.to_s != @context
           raise(
             GLogin::Codec::DecodingError,
             "Context '#{@context}' expected, but '#{ctx}' found"
           )
         end
-        { login: login, avatar: avatar, bearer: bearer }
+        { id: id, login: login, avatar: avatar, bearer: bearer }
       end
     end
 
@@ -75,6 +75,11 @@ module GLogin
         raise 'Secret can\'t be nil' if secret.nil?
         @secret = secret
         @context = context.to_s
+      end
+
+      # GitHub id of the authenticated user
+      def id
+        @json['id']
       end
 
       # GitHub login name of the authenticated user
@@ -91,6 +96,7 @@ module GLogin
       def to_s
         Codec.new(@secret).encrypt(
           [
+            id,
             login,
             avatar_url,
             @json['bearer'],

--- a/test/glogin/test_cookie.rb
+++ b/test/glogin/test_cookie.rb
@@ -30,7 +30,8 @@ class TestCookie < Minitest::Test
     user = GLogin::Cookie::Closed.new(
       GLogin::Cookie::Open.new(
         JSON.parse(
-          "{\"login\":\"yegor256\",\
+          "{\"id\":\"123\",
+          \"login\":\"yegor256\",
           \"avatar_url\":\"https://avatars1.githubusercontent.com/u/526301\"}"
         ),
         secret
@@ -46,30 +47,33 @@ class TestCookie < Minitest::Test
     context = '127.0.0.1'
     user = GLogin::Cookie::Closed.new(
       GLogin::Cookie::Open.new(
-        JSON.parse('{"login":"jeffrey","avatar_url":"#"}'),
+        JSON.parse('{"id":"123","login":"jeffrey","avatar_url":"#"}'),
         secret,
         context
       ).to_s,
       secret,
       context
     ).to_user
+    assert_equal(user[:id], '123')
     assert_equal(user[:login], 'jeffrey')
     assert_equal(user[:avatar], '#')
   end
 
   def test_decrypts_in_test_mode
     user = GLogin::Cookie::Closed.new(
-      'test|http://example.com', ''
+      '123|test|http://example.com', ''
     ).to_user
+    assert_equal(user[:id], '123')
     assert_equal(user[:login], 'test')
     assert_equal(user[:avatar], 'http://example.com')
   end
 
   def test_decrypts_in_test_mode_with_context
     user = GLogin::Cookie::Closed.new(
-      'tester', '', 'some context'
+      '123', '', 'some context'
     ).to_user
-    assert_equal('tester', user[:login])
+    assert_equal('123', user[:id])
+    assert_nil(user[:login])
     assert_nil(user[:avatar])
   end
 


### PR DESCRIPTION
Hello,

I added the ID of the authenticated user to the cookie for easy access. The ID can be used for unique identification of the user.