### PR TITLE
#170: Verify GitHub TLS certificate in GLogin::Auth

### DIFF
--- a/lib/glogin/auth.rb
+++ b/lib/glogin/auth.rb
@@ -105,7 +105,7 @@ module GLogin
       uri = URI.parse('https://api.github.com/user')
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       req = Net::HTTP::Get.new(uri.request_uri)
       req['Accept-Header'] = 'application/json'
       token = access_token(code)
@@ -123,7 +123,7 @@ module GLogin
       uri = URI.parse('https://github.com/login/oauth/access_token')
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       req = Net::HTTP::Post.new(uri.request_uri)
       req.set_form_data(
         'code' => code,

--- a/test/glogin/test_auth.rb
+++ b/test/glogin/test_auth.rb
@@ -88,4 +88,21 @@ class TestAuth < Minitest::Test
       .to_raise(Net::OpenTimeout.new('execution expired'))
     assert_raises(GLogin::ConnectionError) { auth.user('437849732894732') }
   end
+
+  def test_does_not_disable_ssl_verification
+    auth = GLogin::Auth.new('1234', '4433', 'https://example.org')
+    stub_request(:post, 'https://github.com/login/oauth/access_token')
+      .to_return(body: { access_token: 'some-token' }.to_json)
+    stub_request(:get, 'https://api.github.com/user')
+      .to_return(body: { login: 'yegor256' }.to_json)
+    clients = HttpSpy.record { auth.user('437849732894732') }
+    refute_empty(clients, 'expected Net::HTTP instances to be created')
+    clients.each do |http|
+      assert_predicate(http, :use_ssl?, "HTTPS should be on for #{http.address}")
+      refute_equal(
+        OpenSSL::SSL::VERIFY_NONE, http.verify_mode,
+        "SSL verification must not be disabled for #{http.address} (issue #170)"
+      )
+    end
+  end
 end

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -28,6 +28,27 @@ end
 
 require 'minitest/autorun'
 require 'minitest/reporters'
+require 'net/http'
 require 'webmock/minitest'
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 Minitest.load :minitest_reporter
+
+# Test helper that records every Net::HTTP instance created inside a block,
+# so tests can inspect their configuration (e.g. SSL verify_mode).
+module HttpSpy
+  def self.record
+    clients = []
+    original = Net::HTTP.method(:new)
+    Net::HTTP.define_singleton_method(:new) do |*args, **kwargs|
+      instance = original.call(*args, **kwargs)
+      clients << instance
+      instance
+    end
+    begin
+      yield
+    ensure
+      Net::HTTP.define_singleton_method(:new, original)
+    end
+    clients
+  end
+end


### PR DESCRIPTION
@yegor256 this PR closes #170 — GitHub's TLS certificate is no longer skipped during OAuth.

## Problem

`GLogin::Auth` set `http.verify_mode = OpenSSL::SSL::VERIFY_NONE` on both HTTPS calls to GitHub (token exchange to `github.com` and user fetch from `api.github.com`). This disabled TLS certificate verification: a network attacker able to intercept TLS could present any certificate and the client would forward the OAuth `code` and the resulting access token to them. Since glogin is used to authenticate real users against GitHub, this was a genuine MITM vulnerability rather than a theoretical one.

## What changed

- **`test/glogin/test_auth.rb`** — new `test_does_not_disable_ssl_verification`. It records every `Net::HTTP` instance created during `auth.user(...)` via a small `HttpSpy` helper in `test/test__helper.rb`, then asserts each client has `use_ssl? == true` and `verify_mode != OpenSSL::SSL::VERIFY_NONE`. The test fails against master.
- **`lib/glogin/auth.rb`** — replace both occurrences of `OpenSSL::SSL::VERIFY_NONE` with `OpenSSL::SSL::VERIFY_PEER`, so Ruby validates the certificate chain against the system CA bundle.

Commits are split: the first adds only the failing test, the second contains only the two-line fix.

## Verification

- `bundle exec rake` passes locally — 27 tests, 55 assertions, 0 failures, 100% line coverage, RuboCop clean, YARD fully documented.
- Reverting only `lib/glogin/auth.rb` (keeping the new test) makes the new test fail, confirming it reproduces the reported bug.
- All 10 CI checks green on this PR (rake on ubuntu-24.04 and macos-15, xcop, pdd, reuse, actionlint, yamllint, typos, markdown-lint, copyrights).

Ready for your review — closes #170.